### PR TITLE
feat: update bilibili hosts

### DIFF
--- a/Config/mihomoConfig.yaml
+++ b/Config/mihomoConfig.yaml
@@ -97,6 +97,7 @@ hosts:
   'services.googleapis.cn': ['services.googleapis.com']
 
   # 屏蔽哔哩哔哩PCDN，解决访问视频卡顿/直播问题
+  '+.mcdn.bilivideo.com': ['0.0.0.0']
   '+.mcdn.bilivideo.cn': ['0.0.0.0']
   '+.edge.mountaintoys.cn': ['0.0.0.0']
   '+.h2.smtcdns.net': ['0.0.0.0']

--- a/Config/mihomoConfig.yaml
+++ b/Config/mihomoConfig.yaml
@@ -96,10 +96,10 @@ hosts:
   # 解决谷歌商店无法下载的问题
   'services.googleapis.cn': ['services.googleapis.com']
 
-  # 屏蔽哔哩哔哩PCDN，解决访问视频卡顿问题
-  '+.mcdn.bilivideo.com': ['0.0.0.0']
+  # 屏蔽哔哩哔哩PCDN，解决访问视频卡顿/直播问题
   '+.mcdn.bilivideo.cn': ['0.0.0.0']
   '+.edge.mountaintoys.cn': ['0.0.0.0']
+  '+.h2.smtcdns.net': ['0.0.0.0']
 
 ntp:
   enable: true

--- a/Config/mihomoConfigLite.yaml
+++ b/Config/mihomoConfigLite.yaml
@@ -97,6 +97,7 @@ hosts:
   'services.googleapis.cn': ['services.googleapis.com']
 
   # 屏蔽哔哩哔哩PCDN，解决访问视频卡顿/直播问题
+  '+.mcdn.bilivideo.com': ['0.0.0.0']
   '+.mcdn.bilivideo.cn': ['0.0.0.0']
   '+.edge.mountaintoys.cn': ['0.0.0.0']
   '+.h2.smtcdns.net': ['0.0.0.0']

--- a/Config/mihomoConfigLite.yaml
+++ b/Config/mihomoConfigLite.yaml
@@ -96,10 +96,10 @@ hosts:
   # 解决谷歌商店无法下载的问题
   'services.googleapis.cn': ['services.googleapis.com']
 
-  # 屏蔽哔哩哔哩PCDN，解决访问视频卡顿问题
-  '+.mcdn.bilivideo.com': ['0.0.0.0']
+  # 屏蔽哔哩哔哩PCDN，解决访问视频卡顿/直播问题
   '+.mcdn.bilivideo.cn': ['0.0.0.0']
   '+.edge.mountaintoys.cn': ['0.0.0.0']
+  '+.h2.smtcdns.net': ['0.0.0.0']
 
 ntp:
   enable: true

--- a/Script/Script.js
+++ b/Script/Script.js
@@ -701,6 +701,7 @@ function main(config) {
     'services.googleapis.cn': ['services.googleapis.com'],
 
     // 屏蔽哔哩哔哩PCDN，解决访问视频/直播卡顿问题
+    '+.mcdn.bilivideo.com': ['0.0.0.0'],
     '+.mcdn.bilivideo.cn': ['0.0.0.0'],
     '+.edge.mountaintoys.cn': ['0.0.0.0'],
     '+.h2.smtcdns.net': ['0.0.0.0'],

--- a/Script/Script.js
+++ b/Script/Script.js
@@ -700,10 +700,10 @@ function main(config) {
     // 解决谷歌商店无法下载的问题
     'services.googleapis.cn': ['services.googleapis.com'],
 
-    // 屏蔽哔哩哔哩PCDN，解决访问视频卡顿问题
-    '+.mcdn.bilivideo.com': ['0.0.0.0'],
+    // 屏蔽哔哩哔哩PCDN，解决访问视频/直播卡顿问题
     '+.mcdn.bilivideo.cn': ['0.0.0.0'],
     '+.edge.mountaintoys.cn': ['0.0.0.0'],
+    '+.h2.smtcdns.net': ['0.0.0.0'],
 
     // 保留机场用于节点解析的 hosts
     ...proxyServerHosts,

--- a/Script/mihomoScript.js
+++ b/Script/mihomoScript.js
@@ -1016,10 +1016,10 @@ function main(config) {
     // 解决谷歌商店无法下载的问题
     'services.googleapis.cn': ['services.googleapis.com'],
 
-    // 屏蔽哔哩哔哩PCDN，解决访问视频卡顿问题
-    '+.mcdn.bilivideo.com': ['0.0.0.0'],
+    // 屏蔽哔哩哔哩PCDN，解决访问视频/直播卡顿问题
     '+.mcdn.bilivideo.cn': ['0.0.0.0'],
     '+.edge.mountaintoys.cn': ['0.0.0.0'],
+    '+.h2.smtcdns.net': ['0.0.0.0'],
 
     // 保留机场用于节点解析的 hosts
     ...proxyServerHosts,

--- a/Script/mihomoScript.js
+++ b/Script/mihomoScript.js
@@ -1017,6 +1017,7 @@ function main(config) {
     'services.googleapis.cn': ['services.googleapis.com'],
 
     // 屏蔽哔哩哔哩PCDN，解决访问视频/直播卡顿问题
+    '+.mcdn.bilivideo.com': ['0.0.0.0'],
     '+.mcdn.bilivideo.cn': ['0.0.0.0'],
     '+.edge.mountaintoys.cn': ['0.0.0.0'],
     '+.h2.smtcdns.net': ['0.0.0.0'],


### PR DESCRIPTION
去掉了 adblockmihomolite 已经有的 `+.mcdn.bilivideo.com`。

加了一个直播的pcdn，主要参考了 [mbga](https://greasyfork.org/zh-CN/scripts/415714-make-bilibili-great-again/discussions/272113)。