### PR TITLE
feat(add): ETag and CDN fonts

### DIFF
--- a/Config/mihomoConfig.yaml
+++ b/Config/mihomoConfig.yaml
@@ -56,12 +56,13 @@ log-level: info
 bind-address: '*'
 unified-delay: true
 tcp-concurrent: true
+etag-support: true
 keep-alive-idle: 600
 keep-alive-interval: 60
 find-process-mode: strict
 external-controller: '127.0.0.1:9090'
 external-ui: ui
-external-ui-url: 'https://github.com/Zephyruso/zashboard/releases/latest/download/dist.zip'
+external-ui-url: 'https://github.com/Zephyruso/zashboard/releases/latest/download/dist-cdn-fonts.zip'
 
 profile:
   store-selected: true

--- a/Config/mihomoConfigLite.yaml
+++ b/Config/mihomoConfigLite.yaml
@@ -56,12 +56,13 @@ log-level: info
 bind-address: '*'
 unified-delay: true
 tcp-concurrent: true
+etag-support: true
 keep-alive-idle: 600
 keep-alive-interval: 60
 find-process-mode: strict
 external-controller: '127.0.0.1:9090'
 external-ui: ui
-external-ui-url: 'https://github.com/Zephyruso/zashboard/releases/latest/download/dist.zip'
+external-ui-url: 'https://github.com/Zephyruso/zashboard/releases/latest/download/dist-cdn-fonts.zip'
 
 profile:
   store-selected: true

--- a/Script/Script.js
+++ b/Script/Script.js
@@ -958,13 +958,14 @@ function main(config) {
   newConfig['bind-address'] = '*';
   newConfig['unified-delay'] = true;
   newConfig['tcp-concurrent'] = true;
+  newConfig['etag-support'] = true;
   newConfig['keep-alive-idle'] = 600;
   newConfig['keep-alive-interval'] = 60;
   newConfig['find-process-mode'] = 'strict';
 
   newConfig['external-controller'] = '127.0.0.1:9090';
   newConfig['external-ui'] = 'ui';
-  newConfig['external-ui-url'] = 'https://github.com/Zephyruso/zashboard/releases/latest/download/dist.zip';
+  newConfig['external-ui-url'] = 'https://github.com/Zephyruso/zashboard/releases/latest/download/dist-cdn-fonts.zip';
 
   newConfig['profile'] = {
     'store-selected': true,

--- a/Script/mihomoScript.js
+++ b/Script/mihomoScript.js
@@ -1267,13 +1267,14 @@ function main(config) {
   newConfig['bind-address'] = '*';
   newConfig['unified-delay'] = true;
   newConfig['tcp-concurrent'] = true;
+  newConfig['etag-support'] = true;
   newConfig['keep-alive-idle'] = 600;
   newConfig['keep-alive-interval'] = 60;
   newConfig['find-process-mode'] = 'strict';
 
   newConfig['external-controller'] = '127.0.0.1:9090';
   newConfig['external-ui'] = 'ui';
-  newConfig['external-ui-url'] = 'https://github.com/Zephyruso/zashboard/releases/latest/download/dist.zip';
+  newConfig['external-ui-url'] = 'https://github.com/Zephyruso/zashboard/releases/latest/download/dist-cdn-fonts.zip';
 
   newConfig['profile'] = {
     'store-selected': true,


### PR DESCRIPTION
bettbox 都会自动加上etag的，路由器里的这几个代理软件都好像不会。。。

然后把字体从内置换成了用cdn加载，js脚本是为了一致也一起改了